### PR TITLE
fix computation of single stock timeline

### DIFF
--- a/api/src/order.js
+++ b/api/src/order.js
@@ -1,0 +1,63 @@
+const storage = require('./storage.js')
+
+exports.getOrdersData = async (db) => {
+  const sql = `select * from ${storage.EVENTS_TABLE} order by date`
+  return storage.call(db, sql)
+}
+
+exports.getOrders = (data) => {
+  let ids = new Set(data.map((item) => item.id))
+  const orders = {}
+
+  ids.forEach(
+    (id) =>
+      (orders[id] = {
+        id: id,
+        size: 0,
+        price: 0,
+        avgRatio: 0,
+      })
+  )
+  const timeline = {}
+  let lastOrder = 0
+
+  data.forEach((item) => {
+    let priceAdded =
+      (item.size - orders[item.id].size) * item.price * item.ratio
+
+    orders[item.id] = {
+      size: item.size,
+      id: item.id,
+      name: item.name,
+      price: orders[item.id].price + priceAdded,
+      currency: item.currency,
+      avgRatio: exports.getAvgCurrencyRatio(
+        orders[item.id],
+        item.size,
+        item.ratio
+      ),
+    }
+    if (timeline[item.date] === undefined) {
+      timeline[item.date] = lastOrder
+    }
+    timeline[item.date] += Math.round(priceAdded)
+    lastOrder = timeline[item.date]
+  })
+  return { timeline, orders }
+}
+
+exports.getTotalOrder = (orderData) => {
+  const lastDate = Object.keys(orderData).pop()
+  return Math.round(orderData[lastDate])
+}
+
+// avg currency rate to CZK thu orders
+exports.getAvgCurrencyRatio = (lastOrder, size, ratio) => {
+  let added = size - lastOrder.size
+  if (added > 0) {
+    avgRatio = (lastOrder.size * lastOrder.avgRatio + added * ratio) / size
+  } else {
+    avgRatio = lastOrder.avgRatio
+  }
+  return avgRatio
+}

--- a/api/src/single_stock.js
+++ b/api/src/single_stock.js
@@ -1,5 +1,6 @@
 const storage = require('./storage.js')
 const { logger } = require('../logs.js')
+const { getOrders } = require('./order.js')
 
 exports.getStock = async (db, id) => {
   let query =
@@ -11,7 +12,7 @@ exports.getStock = async (db, id) => {
   })
 }
 
-exports.getOrdersForStock = async (db, id) => {
+exports.getOrdersDataForStock = async (db, id) => {
   const sql = `select * from ${storage.EVENTS_TABLE} where id=? order by date`
   return storage.call(db, sql, id)
 }
@@ -24,11 +25,44 @@ class Stock {
     this.timeline = []
   }
 
-  async fetchData() {
-    let ordersData = await exports.getOrdersForStock(this.db, this.id)
+  // for given date returns purchase price. (e.g. how much money you spend to buy stock at given time)
+  getPurchasePrice(date, orders) {
+    if (orders[date]) {
+      return orders[date]
+    }
 
-    ordersData.forEach((item) => {
-      this.orders[item.date] = item.value
+    let currentDate = new Date(date)
+    let purchaseDates = Object.keys(orders)
+      .map((item) => new Date(item))
+      .sort(function (a, b) {
+        return b - a
+      })
+      .reverse()
+      // from format "2022-08-12T12:19:06.122Z" -> "2022-08-12"
+      .map((item) => item.toISOString().split('T')[0])
+
+    // if we have timeline date before we bought the stock, we miss some date, use oldest order
+    let oldestPurchaseDate = new Date(purchaseDates[0])
+    if (currentDate < oldestPurchaseDate) {
+      return orders[purchaseDates[0]]
+    }
+
+    let purchasePrice = 0
+    // when we are missing timeline data (order was placed before we started collecting timeline)
+    purchaseDates.forEach((orderCreatedAt) => {
+      if (new Date(orderCreatedAt) < currentDate) {
+        purchasePrice = orders[orderCreatedAt]
+      }
+    })
+    return purchasePrice
+  }
+
+  async fetchData() {
+    let ordersData = await exports.getOrdersDataForStock(this.db, this.id)
+    let stockOrdersTimeline = Object.entries(getOrders(ordersData)?.timeline)
+
+    stockOrdersTimeline.forEach((item) => {
+      this.orders[item[0]] = item[1]
     })
     // console.log(this.orders)
     this.timeline = await exports.getStock(this.db, [this.id])
@@ -39,30 +73,17 @@ class Stock {
   async getBalance() {
     await this.fetchData()
     let balanceTimeline = []
-    let base = 0
+
     this.timeline.forEach((dayValue) => {
       let date = dayValue['date']
       let stock_value = dayValue['stock_value']
 
-      if (balanceTimeline.length == 0 && !this.orders[date]) {
-        // if we have timeline date before we bought the stock, we miss some date, use last order
-        let lastDate = Object.keys(this.orders)
-          .map((item) => new Date(item))
-          .sort(function (a, b) {
-            a - b
-          })
-          .pop()
+      let purchasePrice = this.getPurchasePrice(date, this.orders)
 
-        // from format "2022-08-12T12:19:06.122Z" -> "2022-08-12"
-        lastDate = lastDate.toISOString().split('T')[0]
-        base = this.orders[lastDate]
-      }
-
-      if (this.orders[date]) {
-        base = this.orders[date]
-      }
-
-      balanceTimeline.push({ date: date, stock_value: stock_value - base })
+      balanceTimeline.push({
+        date: date,
+        stock_value: stock_value - purchasePrice,
+      })
     })
 
     return balanceTimeline

--- a/api/src/stocks_daily.js
+++ b/api/src/stocks_daily.js
@@ -1,5 +1,6 @@
 const storage = require('./storage.js')
-const { getDateString, getOrdersData, getOrders } = require('./data.js')
+const { getDateString } = require('./data.js')
+const { getOrdersData, getOrders } = require('./order.js')
 const { logger } = require('../logs.js')
 
 exports.fillStocksDaily = async (db, from, to) => {

--- a/api/tests/data.test.js
+++ b/api/tests/data.test.js
@@ -1,4 +1,5 @@
 const data = require('../src/data.js')
+const order = require('../src/order.js')
 const { mockDegiro } = require('./mockDegiro.js')
 const { MockFixer } = require('./mockFixer.js')
 const storage = require('../src/storage.js')
@@ -37,14 +38,14 @@ describe('data function', () => {
   it('getAvgCurrencyRatio() should work for buying', () => {
     const lastOrder = { size: 10, avgRatio: 26 }
 
-    const ret = data.getAvgCurrencyRatio(lastOrder, 20, 25)
+    const ret = order.getAvgCurrencyRatio(lastOrder, 20, 25)
     expect(ret).toBe(25.5)
   })
 
   it('getAvgCurrencyRatio() should work for selling', () => {
     const lastOrder = { size: 20, avgRatio: 30 }
 
-    const ret = data.getAvgCurrencyRatio(lastOrder, 10, 20)
+    const ret = order.getAvgCurrencyRatio(lastOrder, 10, 20)
     expect(ret).toBe(30)
   })
 
@@ -133,23 +134,23 @@ describe('data function', () => {
 
   it('computeAndStoreOrdersData() should work', async () => {
     await insertStocks(db)
-    let ordersData = await data.getOrdersData(db)
+    let ordersData = await order.getOrdersData(db)
     expect(ordersData.length).toEqual(13)
 
     await data.computeAndStoreOrdersData(db)
     await data.computeAndStoreOrdersData(db)
 
-    ordersData = await data.getOrdersData(db)
+    ordersData = await order.getOrdersData(db)
     expect(ordersData.length).toEqual(18)
   })
 
   it('getOrdersData(), getOrders() and getTotalOrder() should work', async () => {
-    const ordersData = await data.getOrdersData(db)
+    const ordersData = await order.getOrdersData(db)
     expect(ordersData.length).toEqual(18)
     expect(ordersData[8].value).toEqual(6398)
 
-    const { timeline, orders } = data.getOrders(ordersData)
-    expect(data.getTotalOrder(timeline)).toEqual(65803)
+    const { timeline, orders } = order.getOrders(ordersData)
+    expect(order.getTotalOrder(timeline)).toEqual(65803)
     expect(orders['10306755'].size).toEqual(67)
     expect(orders['10306755'].price).toEqual(5153.25)
     expect(orders['331868'].avgRatio).toEqual(22.59299731525348)
@@ -157,8 +158,8 @@ describe('data function', () => {
   })
 
   it('getStocksBalance() should work', async () => {
-    const ordersData = await data.getOrdersData(db)
-    const { orders } = data.getOrders(ordersData)
+    const ordersData = await order.getOrdersData(db)
+    const { orders } = order.getOrders(ordersData)
 
     const result = await data.getStocksBalance(db, orders)
     expect(result.length).toBe(13)
@@ -171,8 +172,8 @@ describe('data function', () => {
   })
 
   it('sumStocksBalanceByCurrency() should work', async () => {
-    const ordersData = await data.getOrdersData(db)
-    const { orders } = data.getOrders(ordersData)
+    const ordersData = await order.getOrdersData(db)
+    const { orders } = order.getOrders(ordersData)
     const stocksBalance = await data.getStocksBalance(db, orders)
 
     const result = data.sumStocksBalanceByCurrency(stocksBalance)
@@ -184,8 +185,8 @@ describe('data function', () => {
   })
 
   it('getStocksBalance() should work with name change', async () => {
-    const ordersData = await data.getOrdersData(db)
-    const { orders } = data.getOrders(ordersData)
+    const ordersData = await order.getOrdersData(db)
+    const { orders } = order.getOrders(ordersData)
 
     const result = await data.getStocksBalance(db, orders)
     expect(result.length).toBe(13)
@@ -245,7 +246,7 @@ describe('getData() function', () => {
     })
 
     expect(graphData.length).toBe(1)
-    expect(graphData[0].stock_value).toBeCloseTo(83.5)
+    expect(graphData[0].stock_value).toBeCloseTo(106.5)
   })
 
   it('should work for stocks performance', async () => {

--- a/api/tests/orders.js
+++ b/api/tests/orders.js
@@ -21,8 +21,9 @@ exports.stocksInserts = [
 ]
 
 exports.stockATnTInserts = [
-  `INSERT INTO stocks (id, price, size, value, name, currency, created_at, ratio) VALUES ('332126', 27.0, 3.0, 4994.0, 'ATaT made up', 'USD', '2021-08-12', 21.0);`,
-  `INSERT INTO stocks (id, price, size, value, name, currency, created_at, ratio) VALUES ('332126', 72.0, 8.0, 4994.0, 'ATaT made up', 'USD', '2021-09-15', 22.0);`,
+  `INSERT INTO events (id, name, value, price, size, ratio, currency, date) VALUES ('332126', 'AT&T Inc', 3688.0, 28.43, 6.0, 21.61930389126477, 'USD', '2021-07-16');`,
+  `INSERT INTO events (id, name, value, price, size, ratio, currency, date) VALUES ('332126', 'AT&T Inc', 8514.0, 28.19, 14.0, 21.57403557481964, 'USD', '2021-08-16');`,
+  `INSERT INTO events (id, name, value, price, size, ratio, currency, date) VALUES ('332126', 'AT&T Inc', 11287.0, 27.57, 19.0, 21.54700753644885, 'USD', '2021-09-16');`,
 ]
 
 exports.insertStocks = async (db) => {

--- a/api/tests/orders2.js
+++ b/api/tests/orders2.js
@@ -44,14 +44,44 @@ exports.inserts = [
   `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('332126', 11180.583787178788, 11221.53180656253, 11196.606823069513, 'AT&T Inc', 'USD', '2021-09-21', 39.33283052102161, 27.21, 19.0, 21.65729863840599);`,
 ]
 
-exports.monetaInserts = [
-  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('10306755', 3654.2346378720226, 3655.616931256235, 3655.026741094519, 'Moneta random USD', 'USD', '2021-08-12', 2.22915562642356, 28.16, 6.0, 21.6324972839401);`,
-  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('10306755', 3621.204895689399, 3635.5104939570842, 3621.204895689399, 'Moneta random USD', 'USD', '2021-08-13', -13.4324745100339, 28.02, 6.0, 21.53940575594456);`,
-  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('10306755', 3641.7110650367913, 3643.0029100403513, 3641.7110650367913, 'Moneta random USD', 'USD', '2021-08-14', -14.97799513173186, 28.19, 6.0, 21.53075005934014);`,
+exports.sp500Inserts = [
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14626.954355199998, 14633.224224, 14633.224224, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-01', -16.75869599999896, 286.4, 2.0, 25.54683);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14409.070283640001, 14641.0939232, 14409.070283640001, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-02', -14.82002285999988, 281.98, 2.0, 25.549809);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14213.82310014, 14408.9975328, 14213.82310014, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-03', -28.4769851100009, 278.43, 2.0, 25.524949);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14207.38524168, 14388.61139724, 14388.61139724, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-04', -20.44477851000011, 281.69, 2.0, 25.539798);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14363.764213999999, 14403.806870239998, 14363.764213999999, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-05', -14.08913500000017, 281.08, 2.0, 25.551025);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14351.089241599999, 14562.733612, 14562.733612, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-06', -28.42430674999923, 285.25, 2.0, 25.526264);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14561.0877195, 14597.84138526, 14597.84138526, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-07', -30.14609949000078, 285.97, 2.0, 25.523379);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14593.572997040003, 14613.56001228, 14593.572997040003, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-08', -34.41448770999887, 285.97, 2.0, 25.515916);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14543.92622208, 14609.18867486, 14543.92622208, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-09', -28.30539192000106, 284.88, 2.0, 25.526408);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14494.081829119998, 14559.3454931, 14494.081829119998, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-10', -24.95152288000099, 283.84, 2.0, 25.532134);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14477.385810000002, 14496.772632319999, 14477.385810000002, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-11', -37.04384624999875, 283.75, 2.0, 25.510812);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14472.24583272, 14563.84091404, 14563.84091404, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-12', -31.92070045999935, 285.34, 2.0, 25.520153);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14536.60454136, 14568.475406319998, 14543.38143188, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-13', -58.51844361999974, 285.46, 2.0, 25.473589);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14514.34154042, 14544.03456436, 14514.34154042, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-14', -58.4015953299986, 284.89, 2.0, 25.473589);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14514.336982179999, 14524.06027788, 14524.048882279998, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-15', -48.69425347000106, 284.89, 2.0, 25.490626);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14486.688977459999, 14643.12398736, 14643.12398736, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-16', -76.42589063999912, 287.76, 2.0, 25.443293);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14626.27868448, 14670.345616120001, 14626.27868448, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-17', -80.99467152000034, 287.52, 2.0, 25.435237);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14613.612636480002, 14695.43749992, 14695.43749992, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-18', -54.80368307999925, 288.36, 2.0, 25.481061);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14672.956066020002, 14711.101072500001, 14694.468834399999, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-19', -96.18256685000051, 289.15, 2.0, 25.409768);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14682.9281782, 14703.89250884, 14692.088885759998, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-20', -72.47490624000056, 288.64, 2.0, 25.450542);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14689.5188352, 14813.233465679998, 14813.233465679998, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-21', -73.07250282000132, 291.02, 2.0, 25.450542);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14803.045437519999, 14813.233465679998, 14807.56556016, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-22', -78.7404083399997, 291.02, 2.0, 25.440804);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14810.091613759998, 14851.821553599999, 14848.718858760001, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-23', -45.77145773999837, 291.18, 2.0, 25.497491);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14834.94022116, 14870.868921360001, 14855.70310224, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-24', -38.78721425999902, 291.18, 2.0, 25.509484);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14856.181219799999, 15170.37550464, 15061.26045852, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-25', 166.770142020001, 291.18, 2.0, 25.862457);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14819.04936384, 14858.37031104, 14835.27216636, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-26', -59.21815013999912, 291.18, 2.0, 25.474401);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14769.906437299998, 14863.84391268, 14769.906437299998, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-27', -71.89713895000023, 290.15, 2.0, 25.452191);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14772.519528199999, 14820.378112919998, 14820.378112919998, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-28', -69.50850782999987, 291.09, 2.0, 25.456694);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14761.20716, 14772.519528199999, 14765.901206699999, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-29', -75.90236955, 290.15, 2.0, 25.445289);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14609.5000758, 14783.996121299999, 14609.5000758, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-30', -96.23871494999912, 287.49, 2.0, 25.40871);`,
+  `INSERT INTO stocks_by_daily (id, min_value, max_value, last_value, name, currency, date, currency_balance, price, size, ratio) VALUES ('4622757', 14610.601737480001, 14627.735994239998, 14625.340452839999, 'SPDR S&P 500 UCITS ETF', 'EUR', '2019-12-31', -85.00203366000096, 287.58, 2.0, 25.428299);`,
 ]
 
-exports.monetaOrders = [
-  `INSERT INTO events (id, name, value, price, size, ratio, currency, date) VALUES ('10306755', 'USD', 3500.0, 27, 6, 1.0, 'USD', '2021-04-18');`,
+exports.sp500Orders = [
+  `INSERT INTO events (id, name, value, price, size, ratio, currency, date) VALUES ('4622757', 'SPDR S&P 500 UCITS ETF', 6674.0, 258.91, 1.0, 25.778412, 'EUR', '2019-08-27');`,
+  `INSERT INTO events (id, name, value, price, size, ratio, currency, date) VALUES ('4622757', 'SPDR S&P 500 UCITS ETF', 14462.0, 282.68, 2.0, 25.580806, 'EUR', '2019-11-18');`,
+  `INSERT INTO events (id, name, value, price, size, ratio, currency, date) VALUES ('4622757', 'SPDR S&P 500 UCITS ETF', 27069.0, 265.67, 4.0, 25.472566, 'EUR', '2020-03-02');`,
 ]
 
 exports.insertATaTDaily = async (db) => {
@@ -61,15 +91,15 @@ exports.insertATaTDaily = async (db) => {
   return Promise.all(promises)
 }
 
-exports.insertMonetaDaily = async (db) => {
-  const promises = exports.monetaInserts.map((insert) => {
+exports.insertSP500Daily = async (db) => {
+  const promises = exports.sp500Inserts.map((insert) => {
     return storage.run(db, insert)
   })
   return Promise.all(promises)
 }
 
-exports.insertMonetaOrders = async (db) => {
-  const promises = exports.monetaOrders.map((insert) => {
+exports.insertSP500Orders = async (db) => {
+  const promises = exports.sp500Orders.map((insert) => {
     return storage.run(db, insert)
   })
   return Promise.all(promises)

--- a/api/tests/single_stock.test.js
+++ b/api/tests/single_stock.test.js
@@ -1,11 +1,18 @@
 const storage = require('../src/storage.js')
-const { getStock, getOrdersForStock, Stock } = require('../src/single_stock.js')
+const {
+  getStock,
+  getOrdersDataForStock: getOrdersForStock,
+  Stock,
+} = require('../src/single_stock.js')
 const { computeAndStoreOrdersData } = require('../src/data')
+const { getOrders } = require('../src/order.js')
 const sqlite3 = require('sqlite3')
 const {
   insertATaTDaily,
   insertMonetaDaily,
   insertMonetaOrders,
+  insertSP500Daily,
+  insertSP500Orders,
 } = require('./orders2.js')
 const { insertStocks, insertATnTOrders } = require('./orders.js')
 
@@ -46,29 +53,53 @@ describe('Stock class', () => {
   it('method getBalance should return correct timeline data', async () => {
     await insertATaTDaily(db)
     await insertATnTOrders(db)
-    await computeAndStoreOrdersData(db)
 
     let stock = new Stock(db, 332126)
     let balance = await stock.getBalance()
 
-    expect(Object.keys(stock.orders).length).toBe(2)
+    expect(Object.keys(stock.orders).length).toBe(3)
 
     expect(stock.timeline.length).toBe(balance.length)
-    expect(balance[0].stock_value).toBeCloseTo(1954.026, 2)
-    expect(balance[balance.length - 1].stock_value).toBeCloseTo(-1475.393, 2)
+    expect(balance[0].stock_value).toBeCloseTo(-32.9, 0)
+    expect(balance[balance.length - 1].stock_value).toBeCloseTo(-326.3, 0)
   })
 
-  it('getBalance works when first order is older than first timeline entry', async () => {
-    await insertMonetaDaily(db)
-    await insertMonetaOrders(db)
+  it('getPurchasePrice() should work', () => {
+    let stock = new Stock(db, 0)
+    let orders = { '2019-12-14': 20, '2019-12-12': 10 }
 
-    let stock = new Stock(db, 10306755)
+    expect(stock.getPurchasePrice('2019-12-11', orders)).toBe(10)
+    expect(stock.getPurchasePrice('2019-12-12', orders)).toBe(10)
+    expect(stock.getPurchasePrice('2019-12-13', orders)).toBe(10)
+    expect(stock.getPurchasePrice('2019-12-14', orders)).toBe(20)
+    expect(stock.getPurchasePrice('2019-12-15', orders)).toBe(20)
+  })
+})
+
+// Compare Stock output with manually computed correct values
+describe('SP500 stock', () => {
+  it('contains correct orders and balance', async () => {
+    await insertSP500Daily(db)
+    await insertSP500Orders(db)
+
+    let stock = new Stock(db, 4622757)
+    await stock.fetchData()
+
+    expect(stock.orders['2019-08-27']).toBe(6674)
+    expect(stock.orders['2019-11-18']).toBe(13905)
+    expect(stock.orders['2020-03-02']).toBe(27440)
+
+    expect(stock.timeline[23].date).toBe('2019-12-24')
+    expect(stock.timeline[23].stock_value).toBeCloseTo(14855.7, 0)
+
+    expect(stock.timeline[24].date).toBe('2019-12-25')
+    expect(stock.timeline[24].stock_value).toBeCloseTo(15061.2, 0)
+
     let balance = await stock.getBalance()
+    expect(balance[23].date).toBe('2019-12-24')
+    expect(balance[23].stock_value).toBeCloseTo(950.5, 0)
 
-    expect(Object.keys(stock.orders).length).toBe(1)
-
-    expect(stock.timeline.length).toBe(balance.length)
-    expect(balance[0].stock_value).toBeCloseTo(155.026, 2)
-    expect(balance[balance.length - 1].stock_value).toBeCloseTo(141.71, 2)
+    expect(balance[24].date).toBe('2019-12-25')
+    expect(balance[24].stock_value).toBeCloseTo(1155.8, 0)
   })
 })

--- a/api/tests/stocks_daily.test.js
+++ b/api/tests/stocks_daily.test.js
@@ -1,5 +1,6 @@
 const sd = require('../src/stocks_daily.js')
 const data = require('../src/data.js')
+const order = require('../src/order.js')
 const { mockDegiro } = require('./mockDegiro.js')
 const { MockFixer } = require('./mockFixer.js')
 const storage = require('../src/storage.js')
@@ -77,8 +78,8 @@ describe('stocks daily', () => {
     const result = await storage.call(db, sql)
     expect(result[0].no).toBe(0)
 
-    const ordersData = await data.getOrdersData(db)
-    const { orders } = await data.getOrders(ordersData)
+    const ordersData = await order.getOrdersData(db)
+    const { orders } = await order.getOrders(ordersData)
     await sd.fillCurrencyBalance(db, orders, '2018-12-24', '2018-12-26')
 
     const sql2 =


### PR DESCRIPTION
Previously purchase price was wrongly calculated.
Move orders function from data.js to prevent circular dependencies. Add manually computed test for sp500 stock

Signed-off-by: Martin Bartušek <martinbartusek@gmail.com>